### PR TITLE
Add landing page with contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# Landingpage
+# Fabricom Metals Landing Page
+
+This project contains a simple landing page called **Busines** for Fabricom Metals.
+It is built with Node.js and Express to serve a static website with a contact form.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   npm start
+   ```
+3. Open your browser and visit `http://localhost:3000`.
+
+The contact form collects a name, contact number, email address and a note or query.
+Form submissions are logged to the server console and a thank you message is shown
+on the page.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fabricom-landing-page",
+  "version": "1.0.0",
+  "description": "Landing page for Fabricom Metals Busines",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fabricom Metals - Busines</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Fabricom Metals</h1>
+        <p>Busines - Trading Metal Industry Products</p>
+    </header>
+    <section class="hero">
+        <h2>Your Trusted Partner in Metal Trading</h2>
+        <p>We supply quality metal products for all your industrial needs.</p>
+    </section>
+    <section class="contact">
+        <h2>Contact Us</h2>
+        <form id="contact-form">
+            <label for="name">Name:</label>
+            <input type="text" id="name" name="name" required>
+
+            <label for="phone">Contact Number:</label>
+            <input type="tel" id="phone" name="phone" required>
+
+            <label for="email">Email Address:</label>
+            <input type="email" id="email" name="email" required>
+
+            <label for="message">Query / Note:</label>
+            <textarea id="message" name="message" required></textarea>
+
+            <button type="submit">Submit</button>
+        </form>
+        <div id="form-response" class="hidden"></div>
+    </section>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,35 @@
+const form = document.getElementById('contact-form');
+const responseDiv = document.getElementById('form-response');
+
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+
+    const data = {
+        name: form.name.value,
+        phone: form.phone.value,
+        email: form.email.value,
+        message: form.message.value,
+    };
+
+    try {
+        const res = await fetch('/submit', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+        if (res.ok) {
+            const result = await res.json();
+            responseDiv.textContent = result.message;
+            responseDiv.classList.remove('hidden');
+            form.reset();
+        } else {
+            responseDiv.textContent = 'Failed to submit form.';
+            responseDiv.classList.remove('hidden');
+        }
+    } catch (err) {
+        responseDiv.textContent = 'Error submitting form.';
+        responseDiv.classList.remove('hidden');
+    }
+});

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,52 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1em;
+    text-align: center;
+}
+
+.hero {
+    padding: 2em;
+    text-align: center;
+    background-color: #e2e2e2;
+}
+
+.contact {
+    padding: 2em;
+}
+
+label {
+    display: block;
+    margin-top: 1em;
+}
+
+input, textarea {
+    width: 100%;
+    padding: 0.5em;
+    margin-top: 0.5em;
+    box-sizing: border-box;
+}
+
+button {
+    margin-top: 1em;
+    padding: 0.5em 2em;
+    background-color: #333;
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #555;
+}
+
+.hidden {
+    display: none;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+app.post('/submit', (req, res) => {
+  const { name, phone, email, message } = req.body;
+  console.log('Form submission:', { name, phone, email, message });
+  res.json({ message: 'Thank you for contacting us!' });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up simple Express app and static site
- create landing page for Fabricom Metals called Busines
- add contact form that posts name, phone, email and query
- document setup steps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68493d8c98d0833289aca41765d2ec66